### PR TITLE
Avoid unnecessary iteration if DerivedLength == iolist_size(Acc)

### DIFF
--- a/src/pbkdf2.erl
+++ b/src/pbkdf2.erl
@@ -96,7 +96,7 @@ to_hex([Char | Rest]) ->
 	Key :: binary().
 
 pbkdf2(MacFunc, Password, Salt, Iterations, DerivedLength, BlockIndex, Acc) ->
-	case iolist_size(Acc) > DerivedLength of
+	case iolist_size(Acc) >= DerivedLength of
 		true ->
 			<<Bin:DerivedLength/binary, _/binary>> = iolist_to_binary(lists:reverse(Acc)),
 			Bin;


### PR DESCRIPTION
Without this patch call to pbkdf2(MacFunc, Password, Salt, Iterations) takes twice as much time as it should as an extra block is produced just to be immediately discarded.
This is true for any call to pbkdf2 where DerivedLength == HMAC block size.
