### PR TITLE
Remove manual ebin dir creation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,11 +5,6 @@
 %% Require at least R14B03. (couchdb requires this version or newer, and this code hasn't been tested on earlier)
 {require_min_otp_vsn, "R14B03"}.
 
-%% Ensure the ebin directory exists before we try to put files there.
-{pre_hooks, [
-	{compile, "mkdir -p ebin"}
-]}.
-
 
 %% == xref ==
 


### PR DESCRIPTION
Bad style to hardcode (can't transfer between OS).
Works right with modern rebar versions.

In Windows creates "-p" and "ebin" forders and fails because it's already exists!
