### PR TITLE
Add crypto to app.src

### DIFF
--- a/src/pbkdf2.app.src
+++ b/src/pbkdf2.app.src
@@ -2,7 +2,7 @@
 	{description, "Erlang PBKDF2 Key Derivation Function"},
 	{vsn, git},
 	{registered, []},
-	{applications, [kernel, stdlib]},
+	{applications, [kernel, stdlib, crypto]},
 	{modules, [pbkdf2]},
 	{env, []}
 ]}.


### PR DESCRIPTION
Adds crypto to the list of applications that must be starated before pbkdf2 starts.
