### PR TITLE
On Windows mkdir command "-p" is not a parameter, its a directory name

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,12 +5,6 @@
 %% Require at least R14B03. (couchdb requires this version or newer, and this code hasn't been tested on earlier)
 {require_min_otp_vsn, "R14B03"}.
 
-%% Ensure the ebin directory exists before we try to put files there.
-{pre_hooks, [
-	{compile, "mkdir -p ebin"}
-]}.
-
-
 %% == xref ==
 
 %% Enable xref warnings.


### PR DESCRIPTION
The mkdir should not be needed anymore.
So I deleted the pre-hook.
Otherwise, on subsequent builds, it will complain about the "-p" directory.