### PR TITLE
Address test failures in some environments

### DIFF
--- a/test/pbkdf2_eqc.erl
+++ b/test/pbkdf2_eqc.erl
@@ -27,7 +27,7 @@ prop_equivalent() ->
 			%% we assume the ebin of this file is in .eunit, where rebar puts it
 			PortSrcDir = filename:dirname(code:which(?MODULE)) ++ "/../test",
 			%% yeeehaw
-			[] = os:cmd("gcc "++PortSrcDir++"/pbkdf2-port.c -o pbkdf2-port -I"++EIDir++"/include -L"++EIDir++"/lib -lei -lssl -lcrypto"),
+			[] = os:cmd("gcc -Wno-format -Wno-pointer-sign  -Wno-implicit-function-declaration "++PortSrcDir++"/pbkdf2-port.c -o pbkdf2-port -I"++EIDir++"/include -L"++EIDir++"/lib -lei -lssl -lcrypto"),
 			?FORALL({Password, Salt, Iterations, KeySize}, {gen_print_bin(), gen_salt(), gen_iterations(), gen_keysize()},
 				begin
 					Port = open_port({spawn, "./pbkdf2-port"}, [{packet, 4}]),

--- a/test/pbkdf2_tests.erl
+++ b/test/pbkdf2_tests.erl
@@ -39,7 +39,7 @@ pbkdf2_hex(Args) ->
 
 rfc6070_correctness_test_() ->
 	[
-		{timeout, 60,
+		{timeout, 60000, % do not trust the docs - timeout is in msec
 			?_assertEqual(
 				Expected,
 				pbkdf2_hex(Args)


### PR DESCRIPTION

### Turn off certain compiler warnings

This is cowboy code anyway (see orginal comment) so put on some spurs
and chaps and turn off the compiler warnings that were stopping the test
from even running on my machine

----
### Change timeout to 60secs as was probably intended 

Assuming the intention of the author was to give these slow tests a
minute to run. See copy-pasta comment from pipe and other places, on
r16b02 at least, timeout is specified in millis, not seconds